### PR TITLE
Removing need of setting ILCSOFT path manually

### DIFF
--- a/releases/release-atlascvmfs-lxplus.cfg
+++ b/releases/release-atlascvmfs-lxplus.cfg
@@ -55,13 +55,8 @@ ilcsoft_afs_path[arch] = ""
 execfile( versions_file ) # !some settings are overwritten below: install dir, versions depending on distr.
 
 
-# --------- determine install dir (OVERWRITING DEFAULT) ----------------------------------------------
-# should be set by the user by setting the ILCSOFT environment variable
-# e.g. "export ILCSOFT=~/ilcsoft"
-if not os.environ.get('ILCSOFT') is None:
-    ilcsoft_install_prefix = str(os.environ.get('ILCSOFT'))
-else:
-    ilcsoft_install_prefix = "/opt/ilcsoft"
+# --------- determine install dir ----------------------------------------------
+ilcsoft_install_prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
 ilcsoft = ILCSoft( ilcsoft_install_dir )
 # python variable for referring the ILC Home directory

--- a/releases/release-desynaf-cvmfs.cfg
+++ b/releases/release-desynaf-cvmfs.cfg
@@ -30,12 +30,7 @@ execfile( versions_file )
 
 
 # --------- determine install dir ----------------------------------------------
-# should be set by the user by setting the ILCSOFT environment variable e.g. "export ILCSOFT=~/ilcsoft"
-if not os.environ.get('ILCSOFT') is None:
-    ilcsoft_install_prefix = str(os.environ.get('ILCSOFT'))
-else:
-    ilcsoft_install_prefix = "/opt/ilcsoft"
-
+ilcsoft_install_prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
 ilcsoft = ILCSoft( ilcsoft_install_dir )
 

--- a/releases/release-desynaf-standalone.cfg
+++ b/releases/release-desynaf-standalone.cfg
@@ -30,12 +30,7 @@ execfile( versions_file )
 
 
 # --------- determine install dir ----------------------------------------------
-# should be set by the user by setting the ILCSOFT environment variable e.g. "export ILCSOFT=~/ilcsoft"
-if not os.environ.get('ILCSOFT') is None:
-    ilcsoft_install_prefix = str(os.environ.get('ILCSOFT'))
-else:
-    ilcsoft_install_prefix = "/opt/ilcsoft"
-
+ilcsoft_install_prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
 ilcsoft = ILCSoft( ilcsoft_install_dir )
 

--- a/releases/release-nocmake.cfg
+++ b/releases/release-nocmake.cfg
@@ -55,15 +55,11 @@ ilcsoft_afs_path[arch] = ""
 execfile( versions_file ) # !some settings are overwritten below: install dir, versions depending on distr.
 
 
-# --------- determine install dir (OVERWRITING DEFAULT) ----------------------------------------------
-# should be set by the user by setting the ILCSOFT environment variable
-# e.g. "export ILCSOFT=~/ilcsoft"
-if not os.environ.get('ILCSOFT') is None:
-    ilcsoft_install_prefix = str(os.environ.get('ILCSOFT'))
-else:
-    ilcsoft_install_prefix = "/opt/ilcsoft"
+# --------- determine install dir ----------------------------------------------
+ilcsoft_install_prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
 ilcsoft = ILCSoft( ilcsoft_install_dir )
+
 # python variable for referring the ILC Home directory
 # used to link or use already installed packages (SL5)
 # -- overwrites setting in release-versions.py! --

--- a/releases/release-nocmakenoroot.cfg
+++ b/releases/release-nocmakenoroot.cfg
@@ -55,15 +55,11 @@ ilcsoft_afs_path[arch] = ""
 execfile( versions_file ) # !some settings are overwritten below: install dir, versions depending on distr.
 
 
-# --------- determine install dir (OVERWRITING DEFAULT) ----------------------------------------------
-# should be set by the user by setting the ILCSOFT environment variable
-# e.g. "export ILCSOFT=~/ilcsoft"
-if not os.environ.get('ILCSOFT') is None:
-    ilcsoft_install_prefix = str(os.environ.get('ILCSOFT'))
-else:
-    ilcsoft_install_prefix = "/opt/ilcsoft"
+# --------- determine install dir ----------------------------------------------
+ilcsoft_install_prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
 ilcsoft = ILCSoft( ilcsoft_install_dir )
+
 # python variable for referring the ILC Home directory
 # used to link or use already installed packages (SL5)
 # -- overwrites setting in release-versions.py! --

--- a/releases/release-standalone.cfg
+++ b/releases/release-standalone.cfg
@@ -30,12 +30,7 @@ execfile( versions_file )
 
 
 # --------- determine install dir ----------------------------------------------
-# should be set by the user by setting the ILCSOFT environment variable e.g. "export ILCSOFT=~/ilcsoft"
-if not os.environ.get('ILCSOFT') is None:
-    ilcsoft_install_prefix = str(os.environ.get('ILCSOFT'))
-else:
-    ilcsoft_install_prefix = "/opt/ilcsoft"
-
+ilcsoft_install_prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
 ilcsoft = ILCSoft( ilcsoft_install_dir )
 


### PR DESCRIPTION
The installation will be performed in the parent directory with respect to were the ilcinstall command is launched. In this way there is no need to set the ILCSOFT path by hand before the installation, which was a bit cumbersome.